### PR TITLE
feat: User 도메인 구현

### DIFF
--- a/src/main/java/com/jangho/latters/common/exception/CustomException.java
+++ b/src/main/java/com/jangho/latters/common/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.jangho.latters.common.exception;
+
+import com.jangho.latters.common.model.enums.ResponseCode;
+import lombok.Getter;
+import org.apache.coyote.Response;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ResponseCode responseCode;
+    private final String message;
+
+    public CustomException(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+        this.message = responseCode.getMessage();
+    }
+
+    public CustomException(ResponseCode responseCode, String message) {
+        this.responseCode = responseCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/jangho/latters/common/model/enums/ResponseCode.java
+++ b/src/main/java/com/jangho/latters/common/model/enums/ResponseCode.java
@@ -1,0 +1,22 @@
+package com.jangho.latters.common.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode {
+    SUCCESS(HttpStatus.OK, "0000", "성공"),
+    FAIL(HttpStatus.BAD_REQUEST, "0001", "실패"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "0002", "리소스를 찾을 수 없음"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "0003", "인증되지 않은 사용자"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "0004", "권한이 없음"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "0005", "서버 오류")
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/jangho/latters/user/domain/Credential.java
+++ b/src/main/java/com/jangho/latters/user/domain/Credential.java
@@ -1,0 +1,5 @@
+package com.jangho.latters.user.domain;
+
+public interface Credential {
+    void validate();
+}

--- a/src/main/java/com/jangho/latters/user/domain/Email.java
+++ b/src/main/java/com/jangho/latters/user/domain/Email.java
@@ -2,7 +2,6 @@ package com.jangho.latters.user.domain;
 
 import com.jangho.latters.common.exception.CustomException;
 import com.jangho.latters.common.model.enums.ResponseCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
@@ -14,7 +13,7 @@ public class Email implements Credential{
         this.email = email;
     }
 
-    public static Email from (String email) {
+    public static Email from(String email) {
         return new Email(email);
     }
 

--- a/src/main/java/com/jangho/latters/user/domain/Email.java
+++ b/src/main/java/com/jangho/latters/user/domain/Email.java
@@ -1,0 +1,31 @@
+package com.jangho.latters.user.domain;
+
+import com.jangho.latters.common.exception.CustomException;
+import com.jangho.latters.common.model.enums.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class Email implements Credential{
+
+    private final String email;
+
+    private Email(String email) {
+        this.email = email;
+    }
+
+    public static Email from (String email) {
+        return new Email(email);
+    }
+
+    @Override
+    public void validate() {
+        if (!isValidEmail(email)) {
+            throw new CustomException(ResponseCode.FAIL, "이메일 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private boolean isValidEmail(String email) {
+        return email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$");
+    }
+}

--- a/src/main/java/com/jangho/latters/user/domain/Password.java
+++ b/src/main/java/com/jangho/latters/user/domain/Password.java
@@ -5,6 +5,7 @@ import com.jangho.latters.common.model.enums.ResponseCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.StringUtils;
 
 import java.util.Objects;
 
@@ -33,12 +34,16 @@ public class Password implements Credential {
     }
 
     public void changePassword(String currentPassword, String newPassword) {
-        if (match(currentPassword)) {
-            this.password = newPassword;
-            this.validate();
-        } else {
+        if (!StringUtils.hasText(currentPassword)) {
+            throw new CustomException(ResponseCode.FAIL, "기존 비밀번호를 입력해주세요.");
+        } else if (!StringUtils.hasText(newPassword)) {
+            throw new CustomException(ResponseCode.FAIL, "새 비밀번호를 입력해주세요.");
+        } else if (!match(currentPassword)) {
             throw new CustomException(ResponseCode.FAIL, "비밀번호가 일치하지 않습니다.");
         }
+
+        this.password = newPassword;
+        this.validate();
     }
 
     @Override

--- a/src/main/java/com/jangho/latters/user/domain/Password.java
+++ b/src/main/java/com/jangho/latters/user/domain/Password.java
@@ -1,0 +1,50 @@
+package com.jangho.latters.user.domain;
+
+import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+public class Password implements Credential {
+
+    private String password;
+    private final PasswordEncoder passwordEncoder;
+
+    private Password(String password, PasswordEncoder passwordEncoder) {
+        this.password = password;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public static Password of(String password, PasswordEncoder passwordEncoder) {
+        return new Password(password, passwordEncoder);
+    }
+
+    public boolean match(String rawPassword) {
+        return passwordEncoder.matches(rawPassword, password);
+    }
+
+    public void change(String newPassword) {
+        this.password = newPassword;
+        this.validate();
+    }
+
+    @Override
+    public void validate() {
+        if (!isValidPassword(password)) {
+            throw new IllegalArgumentException("비밀번호는 8자 이상이어야 합니다.");
+        }
+
+        this.encode();
+    }
+
+    private void encode() {
+        this.password = passwordEncoder.encode(password);
+    }
+
+    private boolean isValidPassword(String password) {
+        return password.length() >= 8;
+    }
+
+
+
+
+}

--- a/src/main/java/com/jangho/latters/user/domain/User.java
+++ b/src/main/java/com/jangho/latters/user/domain/User.java
@@ -1,14 +1,19 @@
 package com.jangho.latters.user.domain;
 
+import com.jangho.latters.common.exception.CustomException;
+import com.jangho.latters.common.model.enums.ResponseCode;
+import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 
 @Getter
 public class User {
     private Long id;
-    private String email;
-    private String password;
+    private Credential email;
+    private Credential password;
 
     private String name;
 
@@ -16,4 +21,39 @@ public class User {
     private String verificationCode;
     private Instant verificationCodeExpiresIn;
     private Instant activatedAt;
+
+    @Builder
+    public User(Long id, Credential email, Credential password, String name, Instant lastLoginAt, String verificationCode, Instant verificationCodeExpiresIn, Instant activatedAt) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.lastLoginAt = lastLoginAt;
+        this.verificationCode = verificationCode;
+        this.verificationCodeExpiresIn = verificationCodeExpiresIn;
+        this.activatedAt = activatedAt;
+    }
+
+    public static User of(String email, String password, PasswordEncoder passwordEncoder, String name) {
+        return User.builder()
+                .email(Email.from(email))
+                .password(Password.of(password, passwordEncoder))
+                .name(name)
+                .build();
+    }
+
+    public void join() {
+        this.email.validate();
+        this.password.validate();
+        
+        this.activatedAt = Instant.now();
+    }
+
+    public void updateName(String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new CustomException(ResponseCode.FAIL, "이름은 필수입니다.");
+        }
+
+        this.name = name;
+    }
 }

--- a/src/main/java/com/jangho/latters/user/domain/VerificationCode.java
+++ b/src/main/java/com/jangho/latters/user/domain/VerificationCode.java
@@ -1,13 +1,17 @@
 package com.jangho.latters.user.domain;
 
+import ch.qos.logback.core.testUtil.RandomUtil;
 import com.jangho.latters.common.exception.CustomException;
 import com.jangho.latters.common.model.enums.ResponseCode;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Random;
 
 @Getter
 public class VerificationCode {
+    private static final Random random = new Random();
     private final String verificationCode;
     private final Instant verificationCodeExpiresIn;
 
@@ -20,11 +24,25 @@ public class VerificationCode {
         return new VerificationCode(verificationCode, verificationCodeExpiresIn);
     }
 
+    public static VerificationCode generate() {
+
+        return new VerificationCode(digitCode(), Instant.now().plus(1, ChronoUnit.DAYS));
+    }
+
     private boolean isExpired() {
         return Instant.now().isAfter(verificationCodeExpiresIn);
     }
 
-    protected void validate(String verificationCode) {
+    private static String digitCode() {
+        final String characters = "0123456789";
+        char[] randomChars = new char[6];
+        for (int i = 0; i < 6; i++) {
+            randomChars[i] = characters.charAt(random.nextInt(characters.length()));
+        }
+        return new String(randomChars);
+    }
+
+    public void validate(String verificationCode) {
         if (isExpired()) {
             throw new CustomException(ResponseCode.FAIL, "인증 코드가 만료되었습니다.");
         } else if (!this.verificationCode.equals(verificationCode)) {

--- a/src/main/java/com/jangho/latters/user/domain/VerificationCode.java
+++ b/src/main/java/com/jangho/latters/user/domain/VerificationCode.java
@@ -1,0 +1,34 @@
+package com.jangho.latters.user.domain;
+
+import com.jangho.latters.common.exception.CustomException;
+import com.jangho.latters.common.model.enums.ResponseCode;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+public class VerificationCode {
+    private final String verificationCode;
+    private final Instant verificationCodeExpiresIn;
+
+    private VerificationCode(String verificationCode, Instant verificationCodeExpiresIn) {
+        this.verificationCode = verificationCode;
+        this.verificationCodeExpiresIn = verificationCodeExpiresIn;
+    }
+
+    public static VerificationCode of(String verificationCode, Instant verificationCodeExpiresIn) {
+        return new VerificationCode(verificationCode, verificationCodeExpiresIn);
+    }
+
+    private boolean isExpired() {
+        return Instant.now().isAfter(verificationCodeExpiresIn);
+    }
+
+    protected void validate(String verificationCode) {
+        if (isExpired()) {
+            throw new CustomException(ResponseCode.FAIL, "인증 코드가 만료되었습니다.");
+        } else if (!this.verificationCode.equals(verificationCode)) {
+            throw new CustomException(ResponseCode.FAIL, "인증 코드가 일치하지 않습니다.");
+        }
+    }
+}

--- a/src/test/java/com/jangho/latters/user/domain/EmailTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/EmailTest.java
@@ -1,16 +1,17 @@
 package com.jangho.latters.user.domain;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
 
 class EmailTest {
     @Test
     @DisplayName("이메일 검증 성공")
     void validateEmail() {
-        // given
         String email = "test@example.com";
+
+        Assertions.assertDoesNotThrow(() -> Email.from(email).validate());
     }
 
     @Test
@@ -19,6 +20,11 @@ class EmailTest {
         // given
         String email1 = "test@example";
         String email2 = "testexample.com";
+
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(Exception.class, () -> Email.from(email1).validate()),
+                () -> Assertions.assertThrows(Exception.class, () -> Email.from(email2).validate())
+        );
     }
 
 }

--- a/src/test/java/com/jangho/latters/user/domain/EmailTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/EmailTest.java
@@ -1,0 +1,24 @@
+package com.jangho.latters.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailTest {
+    @Test
+    @DisplayName("이메일 검증 성공")
+    void validateEmail() {
+        // given
+        String email = "test@example.com";
+    }
+
+    @Test
+    @DisplayName("이메일 검증 실패")
+    void validateEmailFail() {
+        // given
+        String email1 = "test@example";
+        String email2 = "testexample.com";
+    }
+
+}

--- a/src/test/java/com/jangho/latters/user/domain/PasswordTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/PasswordTest.java
@@ -1,32 +1,63 @@
 package com.jangho.latters.user.domain;
 
+import com.jangho.latters.common.exception.CustomException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 class PasswordTest {
+
+    static PasswordEncoder givenPasswordEncoder;
+
+    @BeforeAll
+    static void beforeAll() {
+        givenPasswordEncoder = new BCryptPasswordEncoder();
+    }
+
     @Test
     @DisplayName("비밀번호 검증 성공")
     void validatePassword() {
-        // given
-        String password = "password1234";
+        String rawPassword = "password1234";
+
+        Password password = Password.of(rawPassword, givenPasswordEncoder);
+        password.validate();
+
+        Assertions.assertDoesNotThrow(password::validate);
     }
 
     @Test
     @DisplayName("비밀번호 검증 실패")
     void validatePasswordFail() {
-        // given
-        String password1 = "1234";
-        String password2 = "password";
+        String rawPassword1 = "1234";
+        String rawPassword2 = "invalid";
+
+        Password password1 = Password.of(rawPassword1, givenPasswordEncoder);
+        Password password2 = Password.of(rawPassword2, givenPasswordEncoder);
+
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(CustomException.class, password1::validate),
+                () -> Assertions.assertThrows(CustomException.class, password2::validate)
+        );
     }
 
     @Test
     @DisplayName("비밀번호 일치")
     void matchPassword() {
         // given
-        String password = "password1234";
-        String rawPassword = "password1234";
+        String savedPassword = "password1234";
+        String enteredPassword = "password1234";
+
+        Password password = Password.of(savedPassword, givenPasswordEncoder);
+
+
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(password::validate),
+                () -> Assertions.assertDoesNotThrow(() -> password.match(enteredPassword)),
+                () -> Assertions.assertTrue(password.match(enteredPassword))
+        );
     }
 
     @Test
@@ -35,6 +66,59 @@ class PasswordTest {
         // given
         String password = "password1234";
         String rawPassword = "password12345";
+
+        Password givenPassword = Password.of(password, givenPasswordEncoder);
+
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(() -> givenPassword.match(rawPassword)),
+                () -> Assertions.assertFalse(givenPassword.match(rawPassword))
+        );
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void changePassword() {
+        // given
+        String savedPassword = "password1234";
+        String newPassword = "newPassword1234";
+
+        Password password = Password.of(savedPassword, givenPasswordEncoder);
+
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(password::validate),
+                () -> Assertions.assertDoesNotThrow(() -> password.changePassword(savedPassword, newPassword)),
+                () -> Assertions.assertTrue(password.match(newPassword))
+        );
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패")
+    void changePasswordFail() {
+        // given
+        String savedPassword = "password1234";
+        String wrongPassword = "wrong";
+
+        Password password = Password.of(savedPassword, givenPasswordEncoder);
+
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(password::validate),
+                () -> Assertions.assertThrows(CustomException.class, () -> password.changePassword(wrongPassword, "newPassword1234"))
+        );
+    }
+
+    @Test
+    @DisplayName("password encoder가 null이면 오류를 반환한다.")
+    void passwordEncoderIsNull() {
+        // given
+        String rawPassword = "password1234";
+        PasswordEncoder passwordEncoder = null;
+        Password invalidPassword = Password.of(rawPassword, passwordEncoder);
+
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(CustomException.class, invalidPassword::validate),
+                () -> Assertions.assertThrows(CustomException.class, () ->
+                        invalidPassword.changePassword(rawPassword, "newPassword1234"))
+        );
     }
 
 }

--- a/src/test/java/com/jangho/latters/user/domain/PasswordTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/PasswordTest.java
@@ -2,7 +2,6 @@ package com.jangho.latters.user.domain;
 
 import com.jangho.latters.common.exception.CustomException;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -10,12 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 class PasswordTest {
 
-    static PasswordEncoder givenPasswordEncoder;
-
-    @BeforeAll
-    static void beforeAll() {
-        givenPasswordEncoder = new BCryptPasswordEncoder();
-    }
+    PasswordEncoder givenPasswordEncoder = new BCryptPasswordEncoder();
 
     @Test
     @DisplayName("비밀번호 검증 성공")

--- a/src/test/java/com/jangho/latters/user/domain/PasswordTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/PasswordTest.java
@@ -1,0 +1,40 @@
+package com.jangho.latters.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordTest {
+    @Test
+    @DisplayName("비밀번호 검증 성공")
+    void validatePassword() {
+        // given
+        String password = "password1234";
+    }
+
+    @Test
+    @DisplayName("비밀번호 검증 실패")
+    void validatePasswordFail() {
+        // given
+        String password1 = "1234";
+        String password2 = "password";
+    }
+
+    @Test
+    @DisplayName("비밀번호 일치")
+    void matchPassword() {
+        // given
+        String password = "password1234";
+        String rawPassword = "password1234";
+    }
+
+    @Test
+    @DisplayName("비밀번호 불일치")
+    void matchPasswordFail() {
+        // given
+        String password = "password1234";
+        String rawPassword = "password12345";
+    }
+
+}

--- a/src/test/java/com/jangho/latters/user/domain/UserTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/UserTest.java
@@ -1,0 +1,51 @@
+package com.jangho.latters.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+    @Test
+    @DisplayName("회원가입 테스트")
+    void createUser() {
+
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트")
+    void createUserFail() {
+
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 테스트")
+    void updateUser() {
+
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 실패 테스트")
+    void updateUserFail() {
+
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 테스트")
+    void deleteUser() {
+
+    }
+
+    @Test
+    @DisplayName("인증코드 검증 성공 테스트")
+    void verifyVerificationCode() {
+
+    }
+
+    @Test
+    @DisplayName("인증코드 검증 실패 테스트")
+    void verifyVerificationCodeFail() {
+
+    }
+
+}

--- a/src/test/java/com/jangho/latters/user/domain/UserTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/UserTest.java
@@ -31,12 +31,6 @@ class UserTest {
     }
 
     @Test
-    @DisplayName("회원탈퇴 테스트")
-    void deleteUser() {
-
-    }
-
-    @Test
     @DisplayName("인증코드 검증 성공 테스트")
     void verifyVerificationCode() {
 

--- a/src/test/java/com/jangho/latters/user/domain/UserTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/UserTest.java
@@ -1,45 +1,160 @@
 package com.jangho.latters.user.domain;
 
+import com.jangho.latters.common.exception.CustomException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.time.Instant;
+
 
 class UserTest {
+
+    PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    User joinedUser;
+
+    @BeforeEach
+    void beforeEach() {
+        String givenEmail = "test@example.com";
+        String givenPassword = "password";
+        String givenName = "John Doe";
+        PasswordEncoder givenPasswordEncoder = new BCryptPasswordEncoder();
+        joinedUser = User.of(givenEmail, givenPassword, givenPasswordEncoder, givenName);
+        joinedUser.join();
+    }
+
     @Test
-    @DisplayName("회원가입 테스트")
+    @DisplayName("회원가입 성공 케이스")
     void createUser() {
+        String givenEmail = "test@example.com";
+        String givenPassword = "password";
+        String givenName = "John Doe";
+        PasswordEncoder givenPasswordEncoder = new BCryptPasswordEncoder();
 
+        User givenUser = User.of(givenEmail, givenPassword, givenPasswordEncoder, givenName);
+
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(givenUser::join),
+                () -> Assertions.assertEquals(givenEmail, givenUser.getEmail()),
+                () -> Assertions.assertEquals(givenName, givenUser.getName()),
+                () -> Assertions.assertNotNull(givenUser.getActivatedAt())
+        );
     }
 
     @Test
-    @DisplayName("회원가입 실패 테스트")
+    @DisplayName("회원가입 실패 케이스")
     void createUserFail() {
+        String givenEmail = "testexample.com";
+        String givenPassword = "password";
+        String givenName = "John Doe";
 
+        User givenUser = User.of(givenEmail, givenPassword, passwordEncoder, givenName);
+
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(CustomException.class,
+                        () -> User.of("testexample.com", "password", passwordEncoder, "John Doe").join()),
+                () -> Assertions.assertThrows(CustomException.class,
+                        () -> User.of("test@example.com", "invalid", passwordEncoder, "John Doe").join()),
+                () -> Assertions.assertThrows(CustomException.class,
+                        () -> User.of("test@example.com", "password", passwordEncoder, "j").join()),
+                () -> Assertions.assertThrows(CustomException.class,
+                        () -> User.of("test@example.com", "password", null, "John Doe").join())
+        );
     }
 
     @Test
-    @DisplayName("회원정보 수정 테스트")
-    void updateUser() {
+    @DisplayName("회원정보 이름 수정 성공 케이스")
+    void updateUserName() {
+        String givenName = "Foo bar";
 
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(() -> joinedUser.updateName(givenName)),
+                () -> Assertions.assertEquals(givenName, joinedUser.getName())
+        );
     }
 
     @Test
-    @DisplayName("회원정보 수정 실패 테스트")
+    @DisplayName("회원정보 이름 수정 실패 케이스")
     void updateUserFail() {
+        String givenName = "F";
 
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.updateName(givenName)),
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.updateName(null)),
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.updateName(""))
+        );
     }
 
     @Test
-    @DisplayName("인증코드 검증 성공 테스트")
+    @DisplayName("비밀번호 변경 성공 케이스")
+    void changePassword() {
+        String currentPassword = "password";
+        String newPassword = "newPassword";
+
+        Assertions.assertDoesNotThrow(() -> joinedUser.changePassword(passwordEncoder, currentPassword, newPassword));
+    }
+
+    @Test
+    @DisplayName("비밀변호 변경 실패 케이스")
+    void changePasswordFail() {
+        String currentPassword = "password";
+        String newPassword = "newPassword";
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.changePassword(passwordEncoder, "invalid", newPassword)),
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.changePassword(passwordEncoder, currentPassword, "invalid")),
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.changePassword(passwordEncoder, currentPassword, null)),
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.changePassword(passwordEncoder, null, newPassword)),
+                () -> Assertions.assertThrows(CustomException.class, () -> joinedUser.changePassword(passwordEncoder, currentPassword, ""))
+        );
+    }
+
+    @Test
+    @DisplayName("인증코드를 생성한다.")
+    void generateVerificationCode() {
+        joinedUser.generateVerificationCode();
+
+        Assertions.assertNotNull(joinedUser.getVerificationCode());
+    }
+
+    @Test
+    @DisplayName("인증코드 검증 성공 케이스")
     void verifyVerificationCode() {
+        VerificationCode verificationCode = VerificationCode.generate();
+        String code = verificationCode.getVerificationCode();
+        User givenUser = User.builder().verificationCode(verificationCode).build();
 
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(() -> givenUser.verifyVerificationCode(code)),
+                () -> Assertions.assertNull(givenUser.getVerificationCode())
+        );
     }
 
     @Test
-    @DisplayName("인증코드 검증 실패 테스트")
+    @DisplayName("인증코드 검증 실패 케이스")
     void verifyVerificationCodeFail() {
+        VerificationCode verificationCode = VerificationCode.generate();
+        String code = "abcdef";
+        User givenUser = User.builder().verificationCode(verificationCode).build();
 
+        Assertions.assertThrows(CustomException.class, () -> givenUser.verifyVerificationCode(code));
     }
 
+    @Test
+    @DisplayName("로그인 시 lastLoginAt이 업데이트 된다")
+    void login() {
+        Instant now = Instant.now();
+        Instant currentValue = this.joinedUser.getLastLoginAt();
+        joinedUser.login();
+
+        Assertions.assertAll(
+                () -> Assertions.assertNotEquals(currentValue, joinedUser.getLastLoginAt()),
+                () -> Assertions.assertNotNull(joinedUser.getLastLoginAt()),
+                () -> Assertions.assertTrue(joinedUser.getLastLoginAt().isAfter(now))
+        );
+    }
 }

--- a/src/test/java/com/jangho/latters/user/domain/VerificationCodeTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/VerificationCodeTest.java
@@ -1,0 +1,38 @@
+package com.jangho.latters.user.domain;
+
+import com.jangho.latters.common.exception.CustomException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+public class VerificationCodeTest {
+
+    @Test
+    @DisplayName("인증 코드가 만료되었거나 코드가 일치하지 않을 때 오류를 반환한다.")
+    void validateExpiredVerificationCode() {
+        String verificationCode = "1234";
+        String wrongCode = "4321";
+        Instant expired = Instant.now().minusSeconds(1);
+        Instant notExpired = Instant.now().plusSeconds(60);
+        VerificationCode expiredCode = VerificationCode.of(verificationCode, expired);
+        VerificationCode validCode = VerificationCode.of(verificationCode, notExpired);
+
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(CustomException.class, () -> expiredCode.validate(verificationCode)),
+                () -> Assertions.assertThrows(CustomException.class, () -> validCode.validate(wrongCode))
+        );
+    }
+
+    @Test
+    @DisplayName("인증 코드가 만료되지 않았고 코드가 일치할 때 오류를 반환하지 않는다.")
+    void validateValidVerificationCode() {
+        String verificationCode = "1234";
+        Instant notExpired = Instant.now().plusSeconds(60);
+        VerificationCode validCode = VerificationCode.of(verificationCode, notExpired);
+
+        Assertions.assertDoesNotThrow(() -> validCode.validate(verificationCode));
+    }
+
+}

--- a/src/test/java/com/jangho/latters/user/domain/VerificationCodeTest.java
+++ b/src/test/java/com/jangho/latters/user/domain/VerificationCodeTest.java
@@ -35,4 +35,12 @@ public class VerificationCodeTest {
         Assertions.assertDoesNotThrow(() -> validCode.validate(verificationCode));
     }
 
+    @Test
+    @DisplayName("인증 코드를 생성한다.")
+    void generateVerificationCode() {
+        VerificationCode verificationCode = VerificationCode.generate();
+
+        Assertions.assertNotNull(verificationCode.getVerificationCode());
+        Assertions.assertNotNull(verificationCode.getVerificationCodeExpiresIn());
+    }
 }


### PR DESCRIPTION
# Description
User 관련 도메인 클래스 구현

# Task
* 공용 오류 응답 코드, Exception 추가
* User Credential 인터페이스 추가, Email/Password 적용
* VerificationCode 도메인 로직 구현
* User 도메인 로직 구현

# Requirements
### Email
* `"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$"` 정규표현식에 어긋날 경우 오류가 발생한다.
* 글자수 제한은 두지 않는다.
### Password
* 글자수 8자 이상이어야 한다.
* Spring Security - PasswordEncoder 사용해 아래의 조건을 만족해야 한다.
  * 단방향 암호화 할 수 있어야 한다.
  * 입력한 비밀번호와 암호화된 비밀번호가 일치하는지 확인할 수 있어야 한다.
* 기존 비밀번호, 신규 비밀번호를 입력해 비밀변호를 변경할 수 있어야 한다.
### VerificationCode
* 인증코드는 6자리의 숫자로 구성되며, 발급 시점부터 1일동안 유효해야 한다.
* 입력한 인증코드와 일치하는지 확인할 수 있어야 한다.
### User
* 이메일, 비밀번호, 이름을 입력해 회원가입 할 수 있어야 한다.
  * 이메일, 비밀번호는 위 정책과 동일하며, 이름은 2글자 ~ 20글자 제한을 둔다.
  * 회원가입이 완료되면 활성일을 저장해야 한다.
* 인증코드를 검증할 수 있어야 한다.
* 비밀번호를 변경할 수 있어야 한다.
* 이름을 변경할 수 있어야 한다.
* 마지막 로그인 시간을 저장할 수 있어야 한다.